### PR TITLE
New Feature: Language Support

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -4,6 +4,7 @@ let t = require('teacher');
 import fs = require('fs');
 
 interface SpellMDSettings {
+    language: string,
     ignoreWordsList: string[];
     mistakeTypeToStatus: {}[];
 }
@@ -128,6 +129,7 @@ function readSettings(): SpellMDSettings {
         catch (err) {
             cfg = JSON.parse('{\
                                 "version": "0.1.0", \
+                                "language": "en", \
                                 "ignoreWordsList": [], \
                                 "mistakeTypeToStatus": { \
                                     "Spelling": "Error", \
@@ -140,6 +142,7 @@ function readSettings(): SpellMDSettings {
     }
 
     return {
+        language: cfg.language,
         ignoreWordsList: cfg.ignoreWordsList,
         mistakeTypeToStatus: cfg.mistakeTypeToStatus
     }
@@ -178,8 +181,9 @@ function convertSeverity(mistakeType: string): number {
 function spellcheckDocument(content: string, cb: (report: SPELLMDProblem[]) => void): void {
     let problemMessage: string;
     let detectedErrors: any = {};
-
-    t.check(content, function(err, docProblems) {
+    console.log('settings.language: ' + settings.language);
+    let teach = new t.Teacher(settings.language);
+    teach.check(content, function(err, docProblems) {
         if (docProblems != null) {
             for (let i = 0; i < docProblems.length; i++) {
                 if (settings.ignoreWordsList.indexOf(docProblems[i].string) === -1) {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
 		"teacher": "^0.0.1"
 	},
 	"devDependencies": {
-		"vscode": "next"
+		"vscode": "0.10.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
 		"commands": [
 			{
 				"command": "Spell.suggestFix",
-				"title": "Spell Checker Suggestions"
+				"title": "Spell Checker: Suggestions"
+			},
+			{
+				"command": "Spell.changeLanguage",
+				"title": "Spell Checker: Change Language"
 			}
 		],
 		"keybindings": [
@@ -51,6 +55,6 @@
 		"teacher": "^0.0.1"
 	},
 	"devDependencies": {
-		"vscode": "0.10.0"
+		"vscode": "next"
 	}
 }


### PR DESCRIPTION
Added language support (the same supported by teacher).

The user can define the language in `spell.json`, simply adding a new line using initials, like: 

```  ...
  "language": "pt"
```

Also added a new **Command**, called: **Spell Checker: Change Language**, which allows the user to change the language and automatically updates `spell.json`