### PR TITLE
Make it clearer this sends text to a web service

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "Spell",
 	"displayName": "Spelling and Grammar Checker",
-	"description": "Detect mistakes as you type and suggest fixes - great for Markdown or any text file.",
+	"description": "Detect mistakes as you type and suggest fixes using a web service - great for Markdown or any text file.",
 	"icon": "images/spellIcon.svg",
 	"version": "0.5.0",
 	"publisher": "seanmcbreen",


### PR DESCRIPTION
Currently the readme has a notice about the extension using a web service but it is possible for a user to install the extension without been informed in any way 

![image](https://cloud.githubusercontent.com/assets/1075126/15068955/87968026-1372-11e6-8ee2-c5e9d76ee3f5.png)

This patch makes a small change to the description to disclose the mechanism used for spell check. Users can then either go ahead or refer to the readme for additional information if they wish. 

