### PR TITLE
Add git-commit to set of spell checked languages

### DIFF
--- a/src/Features/spellProvider.ts
+++ b/src/Features/spellProvider.ts
@@ -305,7 +305,7 @@ export default class SpellProvider implements vscode.CodeActionProvider {
                                             "Missing Word": "Disable", \
                                             "Make I uppercase": "Warning" \
                                     },\
-                                "languageIDs": ["markdown","plaintext"],\
+                                "languageIDs": ["markdown","plaintext", "git-commit"],\
                                 "ignoreRegExp": [ \
                                     "/\\\\(.*\\\\.(jpg|jpeg|png|md|gif|JPG|JPEG|PNG|MD|GIF)\\\\)/g", \
                                     "/((http|https|ftp|git)\\\\S*)/g" \


### PR DESCRIPTION
Currently, only two languages are spell checked by default:
1. Markdown
2. Plain text

The developer can customize this using a workspace specific spell.json file. This, however, doesn't work well for cases where one uses Code in the context of git as git will open Code without a directory and thus the workspace specific spell.json will never be used.

This could be also be addressed by #7 but it seems commit messages --when edited in Code -- should get spell checking by default anyways.
