### PR TITLE
check if an editor is open

### DIFF
--- a/src/Features/spellProvider.ts
+++ b/src/Features/spellProvider.ts
@@ -93,7 +93,9 @@ export default class SpellProvider implements vscode.CodeActionProvider {
     public toggleSpell() {
         if (IsDisabled) {
             IsDisabled = false;
-            this.TriggerDiagnostics(vscode.window.activeTextEditor.document);
+            if (vscode.window.activeTextEditor){
+                this.TriggerDiagnostics(vscode.window.activeTextEditor.document);
+            }
         } else {
             IsDisabled = true;
             if(DEBUG) console.log("Clearing diagnostics as Spell was disabled.")


### PR DESCRIPTION
Attempting to toggle the Spellcheck when editor isn't open throws up an error, this simple fix fixes that.
