### PR TITLE
Configure local AtD server URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ the config file has the following sections/capabilities:
 * `mistakeTypeToStatus` we detect many error types and this is how they map to VS Code Diagnostics.
 * `language` change the dictionary to use e.g. French.
 * `languageIDs` configure more file types to check
+* `languageURIs` optionally specify language URIs for your [After The Deadline](http://afterthedeadline.com) server.
 
 Here is the complete default set of configuration options:
 ``` json

--- a/src/Features/callATD.ts
+++ b/src/Features/callATD.ts
@@ -6,23 +6,11 @@ let crypto = require('crypto');
 let os = require('os');
 
 
-function GetURI(language: String): String {
-    switch (language) {
-        case 'en': return 'https://www.polishmywriting.com/proxy.php?url=/checkDocument';
-        case 'fr': return 'https://fr.service.afterthedeadline.com/checkDocument';
-        case 'de': return 'https://de.service.afterthedeadline.com/checkDocument';
-        case 'pt': return 'https://pt.service.afterthedeadline.com/checkDocument';
-        case 'es': return 'https://es.service.afterthedeadline.com/checkDocument';
-        default: return 'https://www.polishmywriting.com/proxy.php?url=/checkDocument';
-    }
-}
-
-
-function PostToATD(content: String, language: String, fn) {
+function PostToATD(content: String, languageURI: String, fn) {
     let key = crypto.createHash('sha1').update(os.hostname()).digest('hex');
     let parser = new xml2js.Parser;
 
-    request({ method: "POST", url: GetURI(language), form: { data: content, key: key } },
+    request({ method: "POST", url: languageURI, form: { data: content, key: key } },
         function (error, response, body) {
             if (error) return fn(error, null);
 
@@ -34,7 +22,7 @@ function PostToATD(content: String, language: String, fn) {
     );
 }
 
-export function check(language, content, fn) {
+export function check(languageURI, content, fn) {
 
     let ignored = [
         'bias language', 'cliches', 'complex expression',
@@ -43,7 +31,7 @@ export function check(language, content, fn) {
         'redundant expression'
     ];
 
-    PostToATD(content, language, function (error, data) {
+    PostToATD(content, languageURI, function (error, data) {
         if (error || !data || !data.error) return fn(error, null);
         if (!Array.isArray(data.error)) data.error = [data.error];
 

--- a/src/Features/spellProvider.ts
+++ b/src/Features/spellProvider.ts
@@ -9,6 +9,7 @@ let DEBUG: boolean = false;
 
 interface SpellSettings {
     language: string,
+    languageURIs: {}[],
     ignoreWordsList: string[];
     mistakeTypeToStatus: {}[];
     languageIDs: string[];
@@ -325,6 +326,7 @@ export default class SpellProvider implements vscode.CodeActionProvider {
 
         return {
             language: cfg.language,
+            languageURIs: cfg.languageURIs,
             ignoreWordsList: cfg.ignoreWordsList,
             mistakeTypeToStatus: cfg.mistakeTypeToStatus,
             languageIDs: cfg.languageIDs,
@@ -354,7 +356,7 @@ export default class SpellProvider implements vscode.CodeActionProvider {
         let problemMessage: string;
         let detectedErrors: any = {};
 
-        callATD.check(settings.language, content, function (error, docProblems) {
+        callATD.check(GetURI(settings.language), content, function (error, docProblems) {
             if (error != null) console.log(error);
             if (docProblems != null) {
                 for (let i = 0; i < docProblems.length; i++) {
@@ -433,6 +435,19 @@ export default class SpellProvider implements vscode.CodeActionProvider {
                 } else {
                     return lengthUpToFirstIndex + nextOccurrence;
                 }
+            }
+        }
+
+        function GetURI(language: String): String {
+            let languageURIs = settings.languageURIs || [];
+
+            switch (language) {
+                case 'en': return languageURIs['en'] || 'https://www.polishmywriting.com/proxy.php?url=/checkDocument';
+                case 'fr': return languageURIs['fr'] || 'https://fr.service.afterthedeadline.com/checkDocument';
+                case 'de': return languageURIs['de'] || 'https://de.service.afterthedeadline.com/checkDocument';
+                case 'pt': return languageURIs['pt'] || 'https://pt.service.afterthedeadline.com/checkDocument';
+                case 'es': return languageURIs['es'] || 'https://es.service.afterthedeadline.com/checkDocument';
+                default: return 'https://www.polishmywriting.com/proxy.php?url=/checkDocument';
             }
         }
 


### PR DESCRIPTION
Adds an optional settings field `"languageURIs"` for specifying URLs to local AtD servers. When URLs are not specified for currently selected language, the default server is used.

An example of using this setting:
```
"languageURIs": {
  "en": "http://127.0.0.1:1049/checkDocument"
}
```